### PR TITLE
fix(eslint): add rule about rest siblings

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -31,7 +31,10 @@ module.exports = {
         '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
         '@typescript-eslint/no-array-constructor': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            { ignoreRestSiblings: true }
+        ],
         'no-undef': 'off', // see https://github.com/eslint/typescript-eslint-parser/issues/416
         'import/prefer-default-export': 'off',
         'import/extensions': ['error', 'always', {


### PR DESCRIPTION
Правило про спред оператор, которое позволяет писать такие конструкции:
```
const myObj = {
   one: 1,
   two: 2,
   three: 3
}

const { one, ...otherProps } = myObj;

console.log(otherProps);
// { two: 2, three: 3 }
```

https://eslint.org/docs/rules/no-unused-vars