### PR TITLE
Правило для `eslint`, отключающее валидацию `propTypes`

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -49,6 +49,7 @@ module.exports = {
         'space-infix-ops': 'off', // see https://github.com/eslint/typescript-eslint-parser/issues/449
         'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'] }],
         'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'warn'
+        'react-hooks/exhaustive-deps': 'warn',
+        'react/prop-types': 'off'
     }
 };


### PR DESCRIPTION
Предлагаю добавить правило для `eslint`, отключающее проверку наличия `propTypes` (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md), так как при использовании `typescript` отпадает такая необходимость.